### PR TITLE
Add log files and IDE folder to be ignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,10 @@ golangci-lint
 terraform-provider-ansible
 *.tar.gz
 
+# logs
+targets.log
+dryrun.log
+
 # ides
 .idea/
+.vscode/


### PR DESCRIPTION
Visual Studio Code log files (targets.log, dryrun.log) should be ignored, as well as its IDE folders (.vscode/).