### PR TITLE
Update provider resources code and go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tralala/terraform-ansible-provider
+module github.com/ansible/terraform-provider-ansible
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
-	"github.com/tralala/terraform-ansible-provider/provider"
+	"github.com/ansible/terraform-provider-ansible/provider"
 )
 
 func main() {

--- a/provider/resource_group.go
+++ b/provider/resource_group.go
@@ -41,8 +41,8 @@ func resourceGroup() *schema.Resource {
 }
 
 func resourceGroupCreate(data *schema.ResourceData, meta interface{}) error {
-	groupName, okay := data.Get("name").(string)
-	if !okay {
+	groupName, ok := data.Get("name").(string)
+	if !ok {
 		log.Print("WARNING [ansible-group]: couldn't get 'name'!")
 	}
 

--- a/provider/resource_host.go
+++ b/provider/resource_host.go
@@ -41,8 +41,8 @@ func resourceHost() *schema.Resource {
 }
 
 func resourceHostCreate(data *schema.ResourceData, meta interface{}) error {
-	hostName, okay := data.Get("name").(string)
-	if !okay {
+	hostName, ok := data.Get("name").(string)
+	if !ok {
 		log.Print("WARNING [ansible-group]: couldn't get 'name'!")
 	}
 

--- a/provider/resource_vault.go
+++ b/provider/resource_vault.go
@@ -72,7 +72,7 @@ func resourceVaultCreate(data *schema.ResourceData, meta interface{}) error {
 
 	var args interface{}
 
-	// Compute args
+	// Compute arguments (args)
 	if vaultID != "" {
 		args = []string{
 			"view",
@@ -110,24 +110,22 @@ func resourceVaultRead(data *schema.ResourceData, meta interface{}) error {
 		log.Print("WARNING [ansible-vault]: couldn't get 'vault_password_file'!")
 	}
 
-	argsTf, okay := data.Get("args").([]interface{})
+	argsTerraform, okay := data.Get("args").([]interface{})
 	if !okay {
 		log.Print("WARNING [ansible-vault]: couldn't get 'args'!")
 	}
 
 	log.Printf("LOG [ansible-vault]: vault_file = %s, vault_password_file = %s\n", vaultFile, vaultPasswordFile)
 
-	args := interfaceToString(argsTf)
+	args := interfaceToString(argsTerraform)
 
 	cmd := exec.Command("ansible-vault", args...)
 
-	out, err := cmd.CombinedOutput()
+	yamlString, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Fatal("ERROR [ansible-vault]: couldn't access ansible vault file")
 		log.Fatalf("%s with password file %s! %s", vaultFile, vaultPasswordFile, err)
 	}
-
-	yamlString := out
 
 	if err := data.Set("yaml", string(yamlString)); err != nil {
 		log.Fatalf("ERROR [ansible-vault]: couldn't calculate 'yaml' variable! %s", err)


### PR DESCRIPTION
Since the provider is located at "github.com/ansible/terraform-provider-ansible", repository links in go.mod and main.go had to be updated from a mock link "github.com/tralala/terraform-ansible-provider" to the link of the actual repository.
Some of the variables in resources code also had to be changed due to not being descriptive enough, same goes for some of the comments.