### PR TITLE
Link to examples subdirectory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ cd tests/terraform_tests
 # GH actions locally
 ./act
 ```
+
+### Examples
+The [examples](./examples/) subdirectory contains a usage example for this provider.


### PR DESCRIPTION
To make README.md more user-friendly, a link that points to the "examples" subdirectory was added.