### PR TITLE
Mark vault's yaml property as sensitive

### DIFF
--- a/.github/workflows/github-actions-lint.yml
+++ b/.github/workflows/github-actions-lint.yml
@@ -44,8 +44,6 @@ jobs:
         with:
           go-version: '^1.18'
 
-      - name: Build
+      - name: Run tests
         run: |
-          go build -o ~/.terraform.d/plugins/terraform-ansible.com/ansibleprovider/ansible/0.0.2/linux_amd64/terraform-provider-ansible .
-
-      - run: cd ./tests/terraform_tests; ./run_tftest.sh
+          make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-os = $(shell go env GOOS)
-arch = $(shell go env GOARCH)
+build:
+	go build -o terraform-provider-ansible
 
-build-dev:
-	go build -o ~/.terraform.d/plugins/registry.terraform.io/ansible/ansible/1.0.0/$(os)_$(arch)/terraform-provider-ansible .
+test: build
+	cd tests/terraform_tests && ./run_tftest.sh

--- a/README.md
+++ b/README.md
@@ -11,20 +11,27 @@ For more details on using Terraform and Ansible together see these blog posts:
 * [Providing Terraform with that Ansible Magic](https://www.ansible.com/blog/providing-terraform-with-that-ansible-magic)
 
 
-## Requirements 
+## Requirements
 
 - install Go: [official installation guide](https://go.dev/doc/install)
 - install Terraform: [official installation guide](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
 - install Ansible: [official installation guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 
-## Installation to Terraform
+## Installation for Local Development
 
-1. Clone this repository to any location on your computer (or download source code)
-2. Use the command below from ``<local-path-to-repository>/terraform-provider-ansible``
+Run `make`. This will build a `terraform-provider-ansible` binary in the top level of the project. To get Terraform to use this binary, configure the [development overrides](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers) for the provider installation. The easiest way to do this will be to create a config file with the following contents:
 
-```shell
-make build-dev
 ```
+provider_installation {
+  dev_overrides {
+    "ansible/ansible" = "/path/to/project/root"
+  }
+
+  direct {}
+}
+```
+
+The `/path/to/project/root` should point to the location where you have cloned this repo, where the `terraform-provider-ansible` binary will be built. You can then set the `TF_CLI_CONFIG_FILE` environment variable to point to this config file, and Terraform will use the provider binary you just built.
 
 ### Testing
 
@@ -40,8 +47,7 @@ curl -L https://github.com/nektos/act/releases/download/v0.2.34/act_Linux_x86_64
 ./golangci-lint run -v
 
 # tests
-cd tests/terraform_tests
-./run_tftest.sh
+make test
 
 # GH actions locally
 ./act

--- a/provider/resource_vault.go
+++ b/provider/resource_vault.go
@@ -39,8 +39,9 @@ func resourceVault() *schema.Resource {
 
 			// computed
 			"yaml": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			// computed - for debug

--- a/tests/expected_tfstate.json
+++ b/tests/expected_tfstate.json
@@ -2,14 +2,14 @@
   "version": 4,
   "terraform_version": "1.3.6",
   "serial": 4,
-  "lineage": "35ee8a72-da3b-5670-fdb4-6bbe83219393",
+  "lineage": "e0b0c2aa-ac5f-e583-831f-a491e8b2929b",
   "outputs": {},
   "resources": [
     {
       "mode": "managed",
       "type": "ansible_group",
       "name": "group",
-      "provider": "provider[\"terraform-ansible.com/ansibleprovider/ansible\"]",
+      "provider": "provider[\"registry.terraform.io/ansible/ansible\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -32,7 +32,7 @@
       "mode": "managed",
       "type": "ansible_host",
       "name": "host",
-      "provider": "provider[\"terraform-ansible.com/ansibleprovider/ansible\"]",
+      "provider": "provider[\"registry.terraform.io/ansible/ansible\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -50,7 +50,47 @@
               "yaml_number": "24356"
             }
           },
-          "sensitive_attributes": [],
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "variables"
+              },
+              {
+                "type": "index",
+                "value": {
+                  "value": "yaml_hello",
+                  "type": "string"
+                }
+              }
+            ],
+            [
+              {
+                "type": "get_attr",
+                "value": "variables"
+              },
+              {
+                "type": "index",
+                "value": {
+                  "value": "yaml_list",
+                  "type": "string"
+                }
+              }
+            ],
+            [
+              {
+                "type": "get_attr",
+                "value": "variables"
+              },
+              {
+                "type": "index",
+                "value": {
+                  "value": "yaml_number",
+                  "type": "string"
+                }
+              }
+            ]
+          ],
           "private": "bnVsbA==",
           "dependencies": [
             "ansible_vault.secrets"
@@ -62,7 +102,7 @@
       "mode": "managed",
       "type": "ansible_vault",
       "name": "secrets",
-      "provider": "provider[\"terraform-ansible.com/ansibleprovider/ansible\"]",
+      "provider": "provider[\"registry.terraform.io/ansible/ansible\"]",
       "instances": [
         {
           "schema_version": 0,

--- a/tests/integration/provider_test.go
+++ b/tests/integration/provider_test.go
@@ -40,5 +40,5 @@ func TestAnsibleProviderOutputs(t *testing.T) {
 		log.Fatal("Error in " + expectedJSON + "!")
 	}
 
-	assert.JSONEq(t, expected.String(), actual.String(), "Actual and Expected JSON files don't match!")
+	assert.JSONEq(t, expected.Path("resources").String(), actual.Path("resources").String(), "Actual and Expected JSON files don't match!")
 }

--- a/tests/integration/provider_test.go
+++ b/tests/integration/provider_test.go
@@ -40,5 +40,8 @@ func TestAnsibleProviderOutputs(t *testing.T) {
 		log.Fatal("Error in " + expectedJSON + "!")
 	}
 
-	assert.JSONEq(t, expected.Path("resources").String(), actual.Path("resources").String(), "Actual and Expected JSON files don't match!")
+	assert.JSONEq(t,
+		expected.Path("resources").String(),
+		actual.Path("resources").String(),
+		"Actual and Expected JSON files don't match!")
 }

--- a/tests/terraform_tests/ansible-dev.tfrc
+++ b/tests/terraform_tests/ansible-dev.tfrc
@@ -1,0 +1,7 @@
+provider_installation {
+  dev_overrides {
+    "ansible/ansible" = "../../.."
+  }
+
+  direct {}
+}

--- a/tests/terraform_tests/main.tf
+++ b/tests/terraform_tests/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     ansible = {
-      version = "~> 0.0.2"
-      source  = "terraform-ansible.com/ansibleprovider/ansible"
+      version = "~> 1.0.0"
+      source  = "ansible/ansible"
     }
   }
 }


### PR DESCRIPTION
The computed yaml property of the ansible_vault resource should be marked as sensitive. This content will still be written in plain text to the state, but we can prevent this from being shown in stdout.

This also makes some minor changes to the test setup to ensure that things are always cleaned up. There are additionally some issues with how the JSON fixture is being tested against during the integration tests. There are a few ways this can lead to an errant test failure. I've fixed one, where using a different version of Terraform than what was used to generate the fixture would cause a failure. The other would require much more effort, but also seems less likely to be a problem.