### PR TITLE
An example with dependent resources

### DIFF
--- a/examples/dependant_resources/example_resource_dependencies.yml
+++ b/examples/dependant_resources/example_resource_dependencies.yml
@@ -1,0 +1,50 @@
+---
+- name: Example of using resource dependencies
+  hosts: localhost
+  gather_facts: true
+
+  tasks:
+    - name: Set variables 'a' and 'b'
+      ansible.builtin.set_fact:
+        var_a: 5
+        var_b: 6
+      tags:
+        - set_vars
+
+    - name: Create var file with variables 'a' and 'b'
+      ansible.builtin.copy:
+        content: |
+          var_a: {{ var_a }}
+          var_b: {{ var_b }}
+        dest: "./vars_ab.yml"
+      tags:
+        - set_vars
+
+
+    - name: Include vars
+      ansible.builtin.include_vars: 
+        file: ./vars_ab.yml
+      tags:
+        - calc_sum
+
+    - name: Calculate the sum of 'a' and 'b'
+      set_fact:
+        sum_ab: "{{ var_a|int + var_b|int }}"
+      tags:
+        - calc_sum
+
+    - name: Print the result of sum 'a' + 'b'
+      ansible.builtin.debug:
+        var: sum_ab
+      tags:
+        - calc_sum
+
+    - name: Print 'a', 'b' and their sum into file
+      ansible.builtin.copy:
+        content: |
+          a: {{ var_a }}
+          b: {{ var_b }}
+          a + b: {{ sum_ab }}
+        dest: "./sum_ab.txt"
+      tags:
+        - calc_sum

--- a/examples/dependant_resources/simple_resource_dependencies.tf
+++ b/examples/dependant_resources/simple_resource_dependencies.tf
@@ -1,0 +1,61 @@
+# ===============================================
+#  A simple exxample of dependant resources
+# ===============================================
+
+terraform {
+  required_providers {
+    ansible = {
+      source  = "ansible/ansible"
+      version = "~> 1.1.0"
+    }
+  }
+}
+
+# This resource will run example_resource_dependencies.yml with tag
+# "set_vars", so that we'll only set variables 'var_a' and 'var_b'. 
+# With this, the next resource "my_playbook_2" is made
+# dependant on this resource; "my_playbook_1".
+resource "ansible_playbook" "my_playbook_1" {
+    playbook = "example_resource_dependencies.yml"
+
+    # Temporary inventory config
+    name  = "localhost"  # hostname - it's a required parameter
+
+    # Play control
+    tags = [
+      "set_vars"
+    ]
+
+    extra_vars = {
+      ansible_connection = "local"  # set to local 
+    }
+
+}
+
+
+# This resource will run example_resource_dependencies.yml with tag
+# "calc_sum", so that we'll only calculate the sum of variables
+# "var_a" and "var_b" defined in the previous resource. This
+# makes this resource dependant on the previous one.
+resource "ansible_playbook" "my_playbook_2" {
+    playbook = "./example_resource_dependencies.yml"
+
+    # Temporary inventory config
+    name  = "localhost"  # hostname - it's a required parameter
+
+    # Play control
+    tags = [
+      "calc_sum"
+    ]
+
+    extra_vars = {
+      ansible_connection = "local"
+    }
+
+    # Since this resource is dependant on resource "my_playbook_1"
+    # we use "depends_on" list, which is a list of all resources
+    # this resource depends on. In this case, it's only "my_playbook_1"
+    # Removing this line will result in failure, since this resource
+    # couldn't get the things that the previous resource created.
+    depends_on = [ ansible_playbook.my_playbook_1 ]
+}

--- a/examples/dependant_resources/simple_resource_dependencies.tf
+++ b/examples/dependant_resources/simple_resource_dependencies.tf
@@ -27,7 +27,7 @@ resource "ansible_playbook" "my_playbook_1" {
     ]
 
     extra_vars = {
-      ansible_connection = "local"  # set to local 
+      ansible_connection = "local"  # set to local for a localhost connection
     }
 
 }
@@ -49,7 +49,7 @@ resource "ansible_playbook" "my_playbook_2" {
     ]
 
     extra_vars = {
-      ansible_connection = "local"
+      ansible_connection = "local"  # set to local for a localhost connection
     }
 
     # Since this resource is dependant on resource "my_playbook_1"


### PR DESCRIPTION
Since #21 mentioned using ``depends_on`` when two (or more) resources are dependent on one another, this pull request adds a simple example where one resource depends on the finished creation of the previous resource and explains the usage of ``depends_on`` in these situations. This added example resolves issue #21 .