### PR TITLE
remove line 473, 474 fix the case which gather previous ansible inven…

### DIFF
--- a/provider/resource_playbook.go
+++ b/provider/resource_playbook.go
@@ -470,9 +470,6 @@ func resourcePlaybookUpdate(data *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("Temp Inventory File: %s", tempInventoryFile)
 
-	// Get all available temp inventories and pass them as args
-	inventories := providerutils.GetAllInventories(inventoryFileNamePrefix)
-
 	log.Print("[INVENTORIES]:")
 	log.Print(inventories)
 


### PR DESCRIPTION
Problem: ansible_playbook resource gather all inventories include the previous inventory files.

Fix: remove function call to "providerutils.GetAllInventories(inventoryFileNamePrefix)" on provider/resource_playbook.go, line 473-474