### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ The Terraform Provider for Ansible Release Notes
 v1.2.0
 ======
 
+Release Summary
+---------------
+
+The terraform-provider-ansible v1.2.0 includes minor bugfixes and improvements.
+
 Minor Changes
 -------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,19 @@
+================================================
+The Terraform Provider for Ansible Release Notes
+================================================
+
+.. contents:: Topics
+
+v1.2.0
+======
+
+Minor Changes
+-------------
+
+- Update dependencies (google.golang.org/grpc and golang.org/x/net) to resolve security alerts https://github.com/ansible/terraform-provider-ansible/security/dependabot (https://github.com/ansible/terraform-provider-ansible/pull/72).
+- Updates the provider to use SDKv2 (https://github.com/ansible/terraform-provider-ansible/issues/39).
+
+Bugfixes
+--------
+
+- provider/resource_playbook - Fix race condition between multiple ansible_playbook resources (https://github.com/ansible/terraform-provider-ansible/issues/38).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Minor Changes
 -------------
 
 - Update dependencies (google.golang.org/grpc and golang.org/x/net) to resolve security alerts https://github.com/ansible/terraform-provider-ansible/security/dependabot (https://github.com/ansible/terraform-provider-ansible/pull/72).
+- Updates the provider to use Go 1.21 (https://github.com/ansible/terraform-provider-ansible/pull/89)
 - Updates the provider to use SDKv2 (https://github.com/ansible/terraform-provider-ansible/issues/39).
 
 Bugfixes

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -10,10 +10,13 @@ releases:
         security alerts https://github.com/ansible/terraform-provider-ansible/security/dependabot
         (https://github.com/ansible/terraform-provider-ansible/pull/72).
       - Updates the provider to use SDKv2 (https://github.com/ansible/terraform-provider-ansible/issues/39).
+      release_summary: The terraform-provider-ansible v1.2.0 includes minor bugfixes
+        and improvements.
     fragments:
     - aws_example.yml
     - gplv3_licensing.yml
     - inventory_race_conditions.yml
+    - release-summary.yml
     - update_dependencies.yml
     - use_sdkv2.yml
     release_date: '2024-02-19'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,0 +1,19 @@
+ancestor: null
+releases:
+  1.2.0:
+    changes:
+      bugfixes:
+      - provider/resource_playbook - Fix race condition between multiple ansible_playbook
+        resources (https://github.com/ansible/terraform-provider-ansible/issues/38).
+      minor_changes:
+      - Update dependencies (google.golang.org/grpc and golang.org/x/net) to resolve
+        security alerts https://github.com/ansible/terraform-provider-ansible/security/dependabot
+        (https://github.com/ansible/terraform-provider-ansible/pull/72).
+      - Updates the provider to use SDKv2 (https://github.com/ansible/terraform-provider-ansible/issues/39).
+    fragments:
+    - aws_example.yml
+    - gplv3_licensing.yml
+    - inventory_race_conditions.yml
+    - update_dependencies.yml
+    - use_sdkv2.yml
+    release_date: '2024-02-19'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -19,4 +19,4 @@ releases:
     - release-summary.yml
     - update_dependencies.yml
     - use_sdkv2.yml
-    release_date: '2024-02-19'
+    release_date: '2024-02-21'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -9,11 +9,13 @@ releases:
       - Update dependencies (google.golang.org/grpc and golang.org/x/net) to resolve
         security alerts https://github.com/ansible/terraform-provider-ansible/security/dependabot
         (https://github.com/ansible/terraform-provider-ansible/pull/72).
+      - Updates the provider to use Go 1.21 (https://github.com/ansible/terraform-provider-ansible/pull/89)
       - Updates the provider to use SDKv2 (https://github.com/ansible/terraform-provider-ansible/issues/39).
       release_summary: The terraform-provider-ansible v1.2.0 includes minor bugfixes
         and improvements.
     fragments:
     - aws_example.yml
+    - go_version_updates.yml
     - gplv3_licensing.yml
     - inventory_race_conditions.yml
     - release-summary.yml

--- a/changelogs/fragments/aws_example.yml
+++ b/changelogs/fragments/aws_example.yml
@@ -1,2 +1,0 @@
-trivial:
-  - "Added aws example to create ec2 instance with terraform and install nginx with ansible (https://github.com/ansible/terraform-provider-ansible/pull/9)."

--- a/changelogs/fragments/gplv3_licensing.yml
+++ b/changelogs/fragments/gplv3_licensing.yml
@@ -1,2 +1,0 @@
-trivial:
-  - "Add GPLv3 licensing (https://github.com/ansible/terraform-provider-ansible/issues/36)."

--- a/changelogs/fragments/inventory_race_conditions.yml
+++ b/changelogs/fragments/inventory_race_conditions.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - provider/resource_playbook - Fix race condition between multiple ansible_playbook resources (https://github.com/ansible/terraform-provider-ansible/issues/38).

--- a/changelogs/fragments/update_dependencies.yml
+++ b/changelogs/fragments/update_dependencies.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "Update dependencies (google.golang.org/grpc and golang.org/x/net) to resolve security alerts https://github.com/ansible/terraform-provider-ansible/security/dependabot (https://github.com/ansible/terraform-provider-ansible/pull/72)."

--- a/changelogs/fragments/use_sdkv2.yml
+++ b/changelogs/fragments/use_sdkv2.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "Updates the provider to use SDKv2 (https://github.com/ansible/terraform-provider-ansible/issues/39)."

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Use the navigation to the left to read about the available resources.
 terraform {
   required_providers {
     ansible = {
-      version = "~> 1.1.0"
+      version = "~> 1.2.0"
       source  = "ansible/ansible"
     }
   }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     ansible = {
-      version = "~> 1.1.0"
+      version = "~> 1.2.0"
       source  = "ansible/ansible"
     }
   }


### PR DESCRIPTION
1. Updated the version number to `1.2.0`
2. Ran `go generate` to regenerate docs
3. Ran `antsibull-changelog release --version 1.2.0`