### PR TITLE
Clarify usage around non-string variables in docs

### DIFF
--- a/docs/resources/host.md
+++ b/docs/resources/host.md
@@ -3,7 +3,6 @@
 page_title: "ansible_host Resource - terraform-provider-ansible"
 subcategory: ""
 description: |-
-  
 ---
 
 # ansible_host (Resource)
@@ -22,9 +21,10 @@ resource "ansible_host" "host" {
     yaml_hello  = local.decoded_vault_yaml.hello
     yaml_number = local.decoded_vault_yaml.a_number
 
-    # using jsonencode() here is needed to stringify 
-    # a list that looks like: [ element_1, element_2, ..., element_N ]
-    yaml_list = jsonencode(local.decoded_vault_yaml.a_list)
+    # use jsonencode() like below to stringify complex variables,
+    # e.g. a list like: [ element_1, element_2, ..., element_N ]
+    # this must be parsed as JSON from ansible, e.g. with the from_json filter.
+    yaml_list_json = jsonencode(local.decoded_vault_yaml.a_list)
   }
 }
 ```


### PR DESCRIPTION
The documentation for the `ansible_host` module suggested that lists/maps were supported as long as they were JSONified, but I see that is not the case (especially now that I saw #128).
This makes it a bit more clear how to use lists/maps from Terraform in Ansible playbook/role variables.

*As an aside, `jsonencode(some_list)` silently "works" when Ansible expects a list but as a list of characters (from the string result), which ended up in some funny results.*
