### PR TITLE
test(framework): bootstrap unit and acceptance test infrastructure

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    name: Integration Tests
+    name: Tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -30,6 +30,14 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Run tests
+      - name: Run legacy Terraform tests
         run: |
-          make test
+          make legacy-tests
+
+      - name: Run Unit tests
+        run: |
+          make unit-tests
+
+      - name: Run Acceptance tests
+        run: |
+          make acc-tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 build:
 	go build -o terraform-provider-ansible
 
-test: build
+legacy-tests: build
 	cd tests/terraform_tests && ./run_tftest.sh
+
+unit-tests:
+	go test -v -count=1 ./framework/ -run "^Test[^A]"
+
+acc-tests:
+	TF_ACC=1 go test -v -count=1 -tags integration ./framework/ -run "^TestAcc"
+
+tests: legacy-tests unit-tests acc-tests

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ For more details on using Terraform and Ansible together see these blog posts:
 * [Walking on Clouds with Ansible](https://www.ansible.com/blog/walking-on-clouds-with-ansible)
 * [Providing Terraform with that Ansible Magic](https://www.ansible.com/blog/providing-terraform-with-that-ansible-magic)
 
-
 ## Requirements
 
 - install Go: [official installation guide](https://go.dev/doc/install)
@@ -21,7 +20,7 @@ For more details on using Terraform and Ansible together see these blog posts:
 
 Run `make`. This will build a `terraform-provider-ansible` binary in the top level of the project. To get Terraform to use this binary, configure the [development overrides](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers) for the provider installation. The easiest way to do this will be to create a config file with the following contents:
 
-```
+```hcl
 provider_installation {
   dev_overrides {
     "ansible/ansible" = "/path/to/project/root"
@@ -47,13 +46,14 @@ curl -L https://github.com/nektos/act/releases/download/v0.2.34/act_Linux_x86_64
 ./golangci-lint run -v
 
 # tests
-make test
+make tests
 
 # GH actions locally
 ./act
 ```
 
 ### Examples
+
 The [examples](./examples/) subdirectory contains a usage example for this provider.
 
 ## Release notes

--- a/framework/resource_host_test.go
+++ b/framework/resource_host_test.go
@@ -1,0 +1,93 @@
+package framework_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	hostConfigCreate = `
+resource "ansible_host" "test" {
+  name   = "server01"
+  groups = ["web", "production"]
+  variables = {
+    ansible_user = "admin"
+    port         = 22
+  }
+}`
+
+	hostConfigUpdate = `
+resource "ansible_host" "test" {
+  name   = "server01"
+  groups = ["db"]
+}`
+)
+
+// TestHostResource_lifecycle exercises Create and Update in a single unit test
+// run, covering groups (types.List) and dynamic variables (types.Dynamic).
+func TestHostResource_lifecycle(t *testing.T) {
+	t.Parallel()
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: ansibleProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: hostConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ansible_host.test", "id", "server01"),
+					resource.TestCheckResourceAttr("ansible_host.test", "name", "server01"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.#", "2"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.0", "web"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.1", "production"),
+					resource.TestCheckResourceAttr("ansible_host.test", "variables.%", "2"),
+					resource.TestCheckResourceAttr("ansible_host.test", "variables.ansible_user", "admin"),
+					resource.TestCheckResourceAttr("ansible_host.test", "variables.port", "22"),
+				),
+			},
+			{
+				Config: hostConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ansible_host.test", "id", "server01"),
+					resource.TestCheckResourceAttr("ansible_host.test", "name", "server01"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.0", "db"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.#", "1"),
+					resource.TestCheckNoResourceAttr("ansible_host.test", "variables"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccHostResource_basic runs the same two-step lifecycle through the full
+// Terraform engine, verifying plan+apply+refresh produces no spurious diffs.
+func TestAccHostResource_basic(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: ansibleProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: hostConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ansible_host.test", "id", "server01"),
+					resource.TestCheckResourceAttr("ansible_host.test", "name", "server01"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.#", "2"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.0", "web"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.1", "production"),
+					resource.TestCheckResourceAttr("ansible_host.test", "variables.%", "2"),
+					resource.TestCheckResourceAttr("ansible_host.test", "variables.ansible_user", "admin"),
+					resource.TestCheckResourceAttr("ansible_host.test", "variables.port", "22"),
+				),
+			},
+			{
+				Config: hostConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("ansible_host.test", "id", "server01"),
+					resource.TestCheckResourceAttr("ansible_host.test", "name", "server01"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.0", "db"),
+					resource.TestCheckResourceAttr("ansible_host.test", "groups.#", "1"),
+					resource.TestCheckNoResourceAttr("ansible_host.test", "variables"),
+				),
+			},
+		},
+	})
+}

--- a/framework/testhelper_test.go
+++ b/framework/testhelper_test.go
@@ -1,0 +1,50 @@
+package framework_test
+
+import (
+	"context"
+
+	"github.com/ansible/terraform-provider-ansible/framework"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	tfprotov6 "github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// testProvider is a minimal provider that registers all framework resources.
+// Used by unit and acceptance tests in this package without requiring the full
+// muxed provider or any external configuration.
+type testProvider struct{}
+
+func (p *testProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "ansible"
+}
+
+func (p *testProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = schema.Schema{}
+}
+
+func (p *testProvider) Configure(_ context.Context, _ provider.ConfigureRequest, _ *provider.ConfigureResponse) {
+}
+
+func (p *testProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
+}
+
+func (p *testProvider) Resources(_ context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		framework.NewHostResource,
+		framework.NewGroupResource,
+	}
+}
+
+// ansibleProviderFactories returns a protocol v6 provider factory backed by
+// testProvider, suitable for use in ProtoV6ProviderFactories for both unit and
+// acceptance tests. Named distinctly from PR #156's protoV6ProviderFactories(runner)
+// to avoid conflicts when the vault test branch merges.
+func ansibleProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		"ansible": providerserver.NewProtocol6WithError(&testProvider{}),
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-mux v0.23.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
+	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/ini.v1 v1.67.2
 )

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/hashicorp/terraform-plugin-mux v0.23.1 h1:B93b4hEj8cPKh24WJH2dJJAS3a5
 github.com/hashicorp/terraform-plugin-mux v0.23.1/go.mod h1:IwuivHNfDVeuDbVvg6fnAYEEEVx881STwJHsl/00UkQ=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1 h1:2yPUd7esMOpuTaG3y1iEla1iw+tla+3ZEkkBnmOAre4=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1/go.mod h1:sq8qsxh+PwdvTQFcd17kfCoBgQo46ADNMvCpKE7t/gY=
+github.com/hashicorp/terraform-plugin-testing v1.16.0 h1:GB97nGnJ1hESpDrCjqZig38RodSF0gdRzxlDupLXP38=
+github.com/hashicorp/terraform-plugin-testing v1.16.0/go.mod h1:eQPYAy9xFMV7xtIFX8Y+wJGtUB++HBl329zCF6PBMZk=
 github.com/hashicorp/terraform-registry-address v0.4.0 h1:S1yCGomj30Sao4l5BMPjTGZmCNzuv7/GDTDX99E9gTk=
 github.com/hashicorp/terraform-registry-address v0.4.0/go.mod h1:LRS1Ay0+mAiRkUyltGT+UHWkIqTFvigGn/LbMshfflE=
 github.com/hashicorp/terraform-svchost v0.2.1 h1:ubvrTFw3Q7CsoEaX7V06PtCTKG3wu7GyyobAoN4eF3Q=


### PR DESCRIPTION
## Summary

- Adds `github.com/hashicorp/terraform-plugin-testing` as a direct dependency — the canonical testing library for Plugin Framework providers
- Introduces `framework/testhelper_test.go`: a minimal `testProvider` + `ansibleProviderFactories()` shared helper in `package framework_test`, reusable by all future resource tests in the package
- Introduces `framework/resource_host_test.go`: single unit test + single acceptance test for `ansible_host`, covering Create + Update with name, groups, and dynamic variables
- Renames the legacy `test` target to `legacy-tests` and adds `unit-tests` / `acc-tests` targets to the Makefile and CI workflow

This establishes the test patterns and infrastructure for modern Terraform framework tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)