### PR TITLE
perf: preallocate slices with known capacity

### DIFF
--- a/provider/resource_playbook.go
+++ b/provider/resource_playbook.go
@@ -353,7 +353,7 @@ func resourcePlaybookCreate(ctx context.Context, data *schema.ResourceData, meta
 	args = append(args, "-e", "hostname="+name)
 
 	if len(tags) > 0 {
-		tmpTags := []string{}
+		tmpTags := make([]string, 0, len(tags))
 
 		for _, tag := range tags {
 			tagStr, okay := tag.(string)
@@ -373,7 +373,7 @@ func resourcePlaybookCreate(ctx context.Context, data *schema.ResourceData, meta
 	}
 
 	if len(limit) > 0 {
-		tmpLimit := []string{}
+		tmpLimit := make([]string, 0, len(limit))
 
 		for _, l := range limit {
 			limitStr, okay := l.(string)

--- a/providerutils/utils.go
+++ b/providerutils/utils.go
@@ -21,7 +21,7 @@ const DefaultHostGroup = "default"
 func InterfaceToString(arr []any) ([]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	result := []string{}
+	result := make([]string, 0, len(arr))
 
 	for _, val := range arr {
 		tmpVal, ok := val.(string)


### PR DESCRIPTION
## Summary

- Preallocate `tmpTags` and `tmpLimit` slices in `resource_playbook.go` using `make()` with `len(tags)` / `len(limit)` capacity
- Preallocate `result` slice in `providerutils/utils.go` using `make()` with `len(arr)` capacity
- Fixes all 3 `prealloc` warnings reported by golangci-lint