### PR TITLE
fix: documentation for ansible_playbook_run

### DIFF
--- a/docs/actions/playbook_run.md
+++ b/docs/actions/playbook_run.md
@@ -11,16 +11,34 @@ The `ansible_playbook_run` action runs an Ansible playbook.
 
 ## Example Usage
 ```terraform
-action "ansible_playbook_run" "ansible" {
+data "ansible_inventory" "myinventory" {
+  group {
+    name = "webservers"
+
+    host {
+      name = "web1.example.com"
+    }
+  }
+}
+
+action "ansible_playbook_run" "with_inventories" {
   config {
-    playbooks            = ["${path.module}/playbook.yml"]
-    inventory            = [ansible_inventory.myinventory.path]
-    ssh_private_key_file = "./ssh-private-key.pem"
+    playbooks   = ["${path.module}/playbook.yml"]
+    inventories = [data.ansible_inventory.myinventory.json]
 
     extra_vars = {
       var_a = "Some variable"
       var_b = "Another variable"
     }
+  }
+}
+
+action "ansible_playbook_run" "with_inventory_files" {
+  config {
+    playbooks       = ["${path.module}/playbook.yml"]
+    inventory_files = ["./hosts.ini", "./staging.yml"]
+
+    private_key_file = "./ssh-private-key.pem"
   }
 }
 ```

--- a/docs/data-sources/vault.md
+++ b/docs/data-sources/vault.md
@@ -1,30 +1,21 @@
 ---
 page_title: "ansible_vault DataSource - terraform-provider-ansible"
 subcategory: ""
-description: Decrypts an ansible-vault encrypted file and exposes its content.
+description: |-
+  Decrypts an ansible-vault encrypted file and exposes its content.
 ---
 
 # ansible_vault (DataSource)
 
 Decrypts an ansible-vault encrypted file and exposes the plaintext content as a sensitive computed attribute.
 
-The `vault_file` and password attributes are read from configuration on every plan/apply and are never persisted to state. For workflows where even the decrypted content must not appear in state, use the [`ansible_vault` ephemeral resource](../ephemeral-resources/vault.md) instead (requires Terraform 1.10+).
-
-The vault password can be supplied as a file path via `vault_password_file` or as an inline string via `vault_password`. Exactly one of the two must be specified.
+The decrypted `yaml` is stored in Terraform state. For workflows where even the decrypted content must not appear in state, use the [`ansible_vault` ephemeral resource](../ephemeral-resources/vault.md) instead (requires Terraform 1.10+).
 
 ## Example Usage
-
 ```terraform
-# Using a password file
 data "ansible_vault" "secret" {
   vault_file          = "${path.module}/secrets/db_password.yml"
   vault_password_file = "${path.module}/.vault_pass"
-}
-
-# Using an inline password (e.g. sourced from a variable or secret manager)
-data "ansible_vault" "secret" {
-  vault_file     = "${path.module}/secrets/db_password.yml"
-  vault_password = var.vault_password
 }
 
 output "db_password_yaml" {
@@ -42,10 +33,12 @@ output "db_password_yaml" {
 
 ### Optional
 
-- `vault_password` (String, Sensitive) Vault password. Mutually exclusive with `vault_password_file`.
-- `vault_password_file` (String, Sensitive) Path to vault password file. Mutually exclusive with `vault_password`.
-- `vault_id` (String) ID of the encrypted vault file.
+- `vault_id` (String) Vault ID label used with `--vault-id <id>@<vault_password_file>`.
+- `vault_password` (String, Sensitive) Vault password as a plain string.
+- `vault_password_file` (String, Sensitive) Path to the file containing the vault password.
 
 ### Read-Only
 
 - `yaml` (String, Sensitive) Decrypted content of the vault file.
+
+

--- a/docs/data-sources/vault_string.md
+++ b/docs/data-sources/vault_string.md
@@ -1,21 +1,18 @@
 ---
 page_title: "ansible_vault_string DataSource - terraform-provider-ansible"
 subcategory: ""
-description: Decrypts an ansible-vault encrypted string and exposes its plaintext.
+description: |-
+  Decrypts an ansible-vault encrypted string and exposes its plaintext.
 ---
 
 # ansible_vault_string (DataSource)
 
 Decrypts an inline ansible-vault encrypted string (the `$ANSIBLE_VAULT;...` block) and exposes the plaintext as a sensitive computed attribute.
 
-The `content` and password attributes are read from configuration on every plan/apply. For workflows where even the decrypted value must not appear in state, use the [`ansible_vault_string` ephemeral resource](../ephemeral-resources/vault_string.md) instead (requires Terraform 1.10+).
-
-The vault password can be supplied as a file path via `vault_password_file` or as an inline string via `vault_password`. Exactly one of the two must be specified.
+The decrypted `plaintext` is stored in Terraform state. For workflows where even the decrypted value must not appear in state, use the [`ansible_vault_string` ephemeral resource](../ephemeral-resources/vault_string.md) instead (requires Terraform 1.10+).
 
 ## Example Usage
-
 ```terraform
-# Using a password file
 data "ansible_vault_string" "db_password" {
   content = <<-EOT
     $ANSIBLE_VAULT;1.1;AES256
@@ -23,16 +20,6 @@ data "ansible_vault_string" "db_password" {
     3562396563643434386566616637653564623436623437386237613438386231383164
     EOT
   vault_password_file = "${path.module}/.vault_pass"
-}
-
-# Using an inline password (e.g. sourced from a variable or secret manager)
-data "ansible_vault_string" "db_password" {
-  content = <<-EOT
-    $ANSIBLE_VAULT;1.1;AES256
-    66386439653236336462626566653063336164663966303231363934653561363964613
-    3562396563643434386566616637653564623436623437386237613438386231383164
-    EOT
-  vault_password = var.vault_password
 }
 
 output "db_password" {
@@ -50,10 +37,12 @@ output "db_password" {
 
 ### Optional
 
-- `vault_password` (String, Sensitive) Vault password. Mutually exclusive with `vault_password_file`.
-- `vault_password_file` (String, Sensitive) Path to vault password file. Mutually exclusive with `vault_password`.
-- `vault_id` (String) ID of the encrypted vault file.
+- `vault_id` (String) Vault ID label used with `--vault-id <id>@<vault_password_file>`.
+- `vault_password` (String, Sensitive) Vault password as a plain string.
+- `vault_password_file` (String, Sensitive) Path to the file containing the vault password.
 
 ### Read-Only
 
-- `plaintext` (String, Sensitive) Decrypted vault string.
+- `plaintext` (String, Sensitive) Decrypted plaintext of the vault string.
+
+

--- a/docs/ephemeral-resources/vault.md
+++ b/docs/ephemeral-resources/vault.md
@@ -1,31 +1,25 @@
 ---
 page_title: "ansible_vault EphemeralResource - terraform-provider-ansible"
 subcategory: ""
-description: Decrypts an ansible-vault encrypted file.
+description: |-
+  Decrypts an ansible-vault encrypted file.
 ---
 
 # ansible_vault (EphemeralResource)
 
 Decrypts an ansible-vault encrypted file and exposes the plaintext content as a sensitive computed attribute.
 
-The vault password can be supplied as a file path via `vault_password_file` or as an inline string via `vault_password`. Exactly one of the two must be specified.
+Requires Terraform 1.10 or later. Ephemeral resources are ideal for secrets that should never appear in state or plan output.
 
 ## Example Usage
-
 ```terraform
-# Using a password file
 ephemeral "ansible_vault" "secret" {
   vault_file          = "${path.module}/secrets/db_password.yml"
   vault_password_file = "${path.module}/.vault_pass"
 }
 
-# Using an inline password (e.g. sourced from a variable or secret manager)
-ephemeral "ansible_vault" "secret" {
-  vault_file     = "${path.module}/secrets/db_password.yml"
-  vault_password = var.vault_password
-}
-
-# Use the decrypted content in another resource.
+# Use the decrypted content in another resource without it appearing in state.
+# Requires Terraform 1.10 or later.
 resource "aws_secretsmanager_secret_version" "db" {
   secret_id     = aws_secretsmanager_secret.db.id
   secret_string = ephemeral.ansible_vault.secret.yaml
@@ -41,10 +35,12 @@ resource "aws_secretsmanager_secret_version" "db" {
 
 ### Optional
 
-- `vault_password` (String, Sensitive) Vault password. Mutually exclusive with `vault_password_file`.
-- `vault_password_file` (String, Sensitive) Path to vault password file. Mutually exclusive with `vault_password`.
-- `vault_id` (String) ID of the encrypted vault file.
+- `vault_id` (String) Vault ID label used with `--vault-id <id>@<vault_password_file>`.
+- `vault_password` (String, Sensitive) Vault password as a plain string.
+- `vault_password_file` (String, Sensitive) Path to the file containing the vault password.
 
 ### Read-Only
 
 - `yaml` (String, Sensitive) Decrypted content of the vault file.
+
+

--- a/docs/ephemeral-resources/vault_string.md
+++ b/docs/ephemeral-resources/vault_string.md
@@ -1,19 +1,18 @@
 ---
 page_title: "ansible_vault_string EphemeralResource - terraform-provider-ansible"
 subcategory: ""
-description: Decrypts an ansible-vault encrypted string.
+description: |-
+  Decrypts an ansible-vault encrypted string.
 ---
 
 # ansible_vault_string (EphemeralResource)
 
 Decrypts an inline ansible-vault encrypted string (the `$ANSIBLE_VAULT;...` block) and exposes the plaintext as a sensitive computed attribute.
 
-The vault password can be supplied as a file path via `vault_password_file` or as an inline string via `vault_password`. Exactly one of the two must be specified.
+Requires Terraform 1.10 or later. Ephemeral resources are ideal for secrets that should never appear in state or plan output.
 
 ## Example Usage
-
 ```terraform
-# Using a password file
 ephemeral "ansible_vault_string" "db_password" {
   content = <<-EOT
     $ANSIBLE_VAULT;1.1;AES256
@@ -23,17 +22,8 @@ ephemeral "ansible_vault_string" "db_password" {
   vault_password_file = "${path.module}/.vault_pass"
 }
 
-# Using an inline password (e.g. sourced from a variable or secret manager)
-ephemeral "ansible_vault_string" "db_password" {
-  content = <<-EOT
-    $ANSIBLE_VAULT;1.1;AES256
-    66386439653236336462626566653063336164663966303231363934653561363964613
-    3562396563643434386566616637653564623436623437386237613438386231383164
-    EOT
-  vault_password = var.vault_password
-}
-
-# Use the decrypted plaintext in another resource.
+# Use the decrypted plaintext in another resource without it appearing in state.
+# Requires Terraform 1.10 or later.
 resource "aws_secretsmanager_secret_version" "db" {
   secret_id     = aws_secretsmanager_secret.db.id
   secret_string = ephemeral.ansible_vault_string.db_password.plaintext
@@ -49,10 +39,12 @@ resource "aws_secretsmanager_secret_version" "db" {
 
 ### Optional
 
-- `vault_password` (String, Sensitive) Vault password. Mutually exclusive with `vault_password_file`.
-- `vault_password_file` (String, Sensitive) Path to vault password file. Mutually exclusive with `vault_password`.
-- `vault_id` (String) ID of the encrypted vault file.
+- `vault_id` (String) Vault ID label used with `--vault-id <id>@<vault_password_file>`.
+- `vault_password` (String, Sensitive) Vault password as a plain string.
+- `vault_password_file` (String, Sensitive) Path to the file containing the vault password.
 
 ### Read-Only
 
-- `plaintext` (String, Sensitive) Decrypted vault string.
+- `plaintext` (String, Sensitive) Decrypted plaintext of the vault string.
+
+

--- a/examples/actions/ansible_playbook_run/action.tf
+++ b/examples/actions/ansible_playbook_run/action.tf
@@ -1,12 +1,30 @@
-action "ansible_playbook_run" "ansible" {
+data "ansible_inventory" "myinventory" {
+  group {
+    name = "webservers"
+
+    host {
+      name = "web1.example.com"
+    }
+  }
+}
+
+action "ansible_playbook_run" "with_inventories" {
   config {
-    playbooks            = ["${path.module}/playbook.yml"]
-    inventory            = [ansible_inventory.myinventory.path]
-    ssh_private_key_file = "./ssh-private-key.pem"
+    playbooks   = ["${path.module}/playbook.yml"]
+    inventories = [data.ansible_inventory.myinventory.json]
 
     extra_vars = {
       var_a = "Some variable"
       var_b = "Another variable"
     }
+  }
+}
+
+action "ansible_playbook_run" "with_inventory_files" {
+  config {
+    playbooks       = ["${path.module}/playbook.yml"]
+    inventory_files = ["./hosts.ini", "./staging.yml"]
+
+    private_key_file = "./ssh-private-key.pem"
   }
 }


### PR DESCRIPTION
The existing documentation for `ansible_playbook_run` referenced outdated attribute names (`inventory`, `ssh_private_key_file`).

Also, regenerated the documentation using:

```
go generate ./...
```
Which detected some dangling deltas.