### PR TITLE
 feat(inventory): add custom variables to host block

### DIFF
--- a/docs/data-sources/inventory.md
+++ b/docs/data-sources/inventory.md
@@ -21,6 +21,9 @@ data "ansible_inventory" "myinventory" {
       ansible_user             = "ubuntu"
       ansible_private_key_file = local_file.private_key.filename
       ansible_ssh_extra_args   = "-o StrictHostKeyChecking=no"
+      vars = {
+        port = "3000"
+      }
     }
   }
 
@@ -43,7 +46,7 @@ data "ansible_inventory" "myinventory" {
 
 # If you need the inventory as a file you can use the local_file resource
 resource "local_file" "myinventory" {
-  content  = ansible_inventory.myinventory.json
+  content  = data.ansible_inventory.myinventory.json
   filename = "${path.module}/inventory.json"
 }
 
@@ -51,7 +54,7 @@ resource "local_file" "myinventory" {
 action "ansible_playbook_run" "ansible" {
   config {
     playbooks   = ["${path.module}/playbook.yml"]
-    inventories = [data.ansible_inventory.host.json]
+    inventories = [data.ansible_inventory.myinventory.json]
   }
 }
 ```

--- a/docs/data-sources/inventory.md
+++ b/docs/data-sources/inventory.md
@@ -135,6 +135,7 @@ Optional:
 - `ansible_ssh_extra_args` (String) Extra arguments to pass to the ssh command.
 - `ansible_ssh_pipelining` (Boolean) Enable pipelining for SSH connections.
 - `ansible_user` (String) The username to use when connecting (logging in) to the host.
+- `vars` (Map of String) Custom variables to be set for the host.
 
 
 
@@ -168,6 +169,7 @@ Optional:
 - `ansible_ssh_extra_args` (String) Extra arguments to pass to the ssh command.
 - `ansible_ssh_pipelining` (Boolean) Enable pipelining for SSH connections.
 - `ansible_user` (String) The username to use when connecting (logging in) to the host.
+- `vars` (Map of String) Custom variables to be set for the host.
 
 
 
@@ -201,6 +203,7 @@ Optional:
 - `ansible_ssh_extra_args` (String) Extra arguments to pass to the ssh command.
 - `ansible_ssh_pipelining` (Boolean) Enable pipelining for SSH connections.
 - `ansible_user` (String) The username to use when connecting (logging in) to the host.
+- `vars` (Map of String) Custom variables to be set for the host.
 
 
 

--- a/examples/data-sources/ansible_inventory/data-source.tf
+++ b/examples/data-sources/ansible_inventory/data-source.tf
@@ -7,6 +7,9 @@ data "ansible_inventory" "myinventory" {
       ansible_user             = "ubuntu"
       ansible_private_key_file = local_file.private_key.filename
       ansible_ssh_extra_args   = "-o StrictHostKeyChecking=no"
+      vars = {
+        port = "3000"
+      }
     }
   }
 
@@ -29,7 +32,7 @@ data "ansible_inventory" "myinventory" {
 
 # If you need the inventory as a file you can use the local_file resource
 resource "local_file" "myinventory" {
-  content  = ansible_inventory.myinventory.json
+  content  = data.ansible_inventory.myinventory.json
   filename = "${path.module}/inventory.json"
 }
 
@@ -37,6 +40,6 @@ resource "local_file" "myinventory" {
 action "ansible_playbook_run" "ansible" {
   config {
     playbooks   = ["${path.module}/playbook.yml"]
-    inventories = [data.ansible_inventory.host.json]
+    inventories = [data.ansible_inventory.myinventory.json]
   }
 }

--- a/framework/data_inventory.go
+++ b/framework/data_inventory.go
@@ -148,7 +148,7 @@ func sharedGroupToJson(ctx context.Context, group SharedGroupModel) (map[string]
 
 	hostsJson := map[string]json.RawMessage{}
 	for _, host := range hosts {
-		hostJson, diags := hostToJson(&host)
+		hostJson, diags := hostToJson(ctx, &host)
 		if diags.HasError() {
 			return nil, diags
 		}
@@ -180,31 +180,42 @@ func sharedGroupToJson(ctx context.Context, group SharedGroupModel) (map[string]
 	return jsonValue, diags
 }
 
-func hostToJson(hostModel *HostModel) (json.RawMessage, diag.Diagnostics) {
+func hostToJson(ctx context.Context, hostModel *HostModel) (json.RawMessage, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
-	ret, err := json.Marshal(JsonHostModel{
-		AnsibleConnection:        hostModel.AnsibleConnection.ValueString(),
-		AnsibleHost:              hostModel.AnsibleHost.ValueString(),
-		AnsiblePort:              hostModel.AnsiblePort.ValueInt64(),
-		AnsibleUser:              hostModel.AnsibleUser.ValueString(),
-		AnsiblePassword:          hostModel.AnsiblePassword.ValueString(),
-		AnsiblePrivateKeyFile:    hostModel.AnsiblePrivateKeyFile.ValueString(),
-		AnsibleSSHCommonArgs:     hostModel.AnsibleSSHCommonArgs.ValueString(),
-		AnsibleSftpExtraArgs:     hostModel.AnsibleSftpExtraArgs.ValueString(),
-		AnsibleScpExtraArgs:      hostModel.AnsibleScpExtraArgs.ValueString(),
-		AnsibleSSHExtraArgs:      hostModel.AnsibleSSHExtraArgs.ValueString(),
-		AnsibleSSHPipelining:     hostModel.AnsibleSSHPipelining.ValueBool(),
-		AnsibleSSHExecutable:     hostModel.AnsibleSSHExecutable.ValueString(),
-		AnsibleBecome:            hostModel.AnsibleBecome.ValueBool(),
-		AnsibleBecomeMethod:      hostModel.AnsibleBecomeMethod.ValueString(),
-		AnsibleBecomeUser:        hostModel.AnsibleBecomeUser.ValueString(),
-		AnsibleBecomePassword:    hostModel.AnsibleBecomePassword.ValueString(),
-		AnsibleBecomeExe:         hostModel.AnsibleBecomeExe.ValueString(),
-		AnsibleBecomeFlags:       hostModel.AnsibleBecomeFlags.ValueString(),
-		AnsibleShellType:         hostModel.AnsibleShellType.ValueString(),
-		AnsiblePythonInterpreter: hostModel.AnsiblePythonInterpreter.ValueString(),
-		AnsibleShellExecutable:   hostModel.AnsibleShellExecutable.ValueString(),
-	})
+
+	var hostVars map[string]string
+	if !hostModel.Vars.IsNull() && !hostModel.Vars.IsUnknown() {
+		if errDiag := hostModel.Vars.ElementsAs(ctx, &hostVars, false); errDiag.HasError() {
+			diags.Append(errDiag...)
+			return nil, diags
+		}
+	}
+
+	ret, err := json.Marshal(
+		JsonHostModel{
+			AnsibleConnection:        hostModel.AnsibleConnection.ValueString(),
+			AnsibleHost:              hostModel.AnsibleHost.ValueString(),
+			AnsiblePort:              hostModel.AnsiblePort.ValueInt64(),
+			AnsibleUser:              hostModel.AnsibleUser.ValueString(),
+			AnsiblePassword:          hostModel.AnsiblePassword.ValueString(),
+			AnsiblePrivateKeyFile:    hostModel.AnsiblePrivateKeyFile.ValueString(),
+			AnsibleSSHCommonArgs:     hostModel.AnsibleSSHCommonArgs.ValueString(),
+			AnsibleSftpExtraArgs:     hostModel.AnsibleSftpExtraArgs.ValueString(),
+			AnsibleScpExtraArgs:      hostModel.AnsibleScpExtraArgs.ValueString(),
+			AnsibleSSHExtraArgs:      hostModel.AnsibleSSHExtraArgs.ValueString(),
+			AnsibleSSHPipelining:     hostModel.AnsibleSSHPipelining.ValueBool(),
+			AnsibleSSHExecutable:     hostModel.AnsibleSSHExecutable.ValueString(),
+			AnsibleBecome:            hostModel.AnsibleBecome.ValueBool(),
+			AnsibleBecomeMethod:      hostModel.AnsibleBecomeMethod.ValueString(),
+			AnsibleBecomeUser:        hostModel.AnsibleBecomeUser.ValueString(),
+			AnsibleBecomePassword:    hostModel.AnsibleBecomePassword.ValueString(),
+			AnsibleBecomeExe:         hostModel.AnsibleBecomeExe.ValueString(),
+			AnsibleBecomeFlags:       hostModel.AnsibleBecomeFlags.ValueString(),
+			AnsibleShellType:         hostModel.AnsibleShellType.ValueString(),
+			AnsiblePythonInterpreter: hostModel.AnsiblePythonInterpreter.ValueString(),
+			AnsibleShellExecutable:   hostModel.AnsibleShellExecutable.ValueString(),
+			Vars:                     hostVars,
+		})
 	if err != nil {
 		diags.Append(diag.NewErrorDiagnostic("Could not marshal host when marshalling inventory to JSON", err.Error()))
 		return nil, diags
@@ -236,6 +247,7 @@ type HostModel struct {
 	AnsibleShellType         types.String `tfsdk:"ansible_shell_type"`
 	AnsiblePythonInterpreter types.String `tfsdk:"ansible_python_interpreter"`
 	AnsibleShellExecutable   types.String `tfsdk:"ansible_shell_executable"`
+	Vars                     types.Map    `tfsdk:"vars"`
 }
 
 // JsonHostModel represents the JSON structure for Ansible inventory hosts.
@@ -243,27 +255,54 @@ type HostModel struct {
 //
 //nolint:tagliatelle // Ansible requires snake_case JSON field names
 type JsonHostModel struct {
-	AnsibleConnection        string `json:"ansible_connection,omitempty"`
-	AnsibleHost              string `json:"ansible_host,omitempty"`
-	AnsiblePort              int64  `json:"ansible_port,omitempty"`
-	AnsibleUser              string `json:"ansible_user,omitempty"`
-	AnsiblePassword          string `json:"ansible_password,omitempty"`
-	AnsiblePrivateKeyFile    string `json:"ansible_private_key_file,omitempty"`
-	AnsibleSSHCommonArgs     string `json:"ansible_ssh_common_args,omitempty"`
-	AnsibleSftpExtraArgs     string `json:"ansible_sftp_extra_args,omitempty"`
-	AnsibleScpExtraArgs      string `json:"ansible_scp_extra_args,omitempty"`
-	AnsibleSSHExtraArgs      string `json:"ansible_ssh_extra_args,omitempty"`
-	AnsibleSSHPipelining     bool   `json:"ansible_ssh_pipelining,omitempty"`
-	AnsibleSSHExecutable     string `json:"ansible_ssh_executable,omitempty"`
-	AnsibleBecome            bool   `json:"ansible_become,omitempty"`
-	AnsibleBecomeMethod      string `json:"ansible_become_method,omitempty"`
-	AnsibleBecomeUser        string `json:"ansible_become_user,omitempty"`
-	AnsibleBecomePassword    string `json:"ansible_become_password,omitempty"`
-	AnsibleBecomeExe         string `json:"ansible_become_exe,omitempty"`
-	AnsibleBecomeFlags       string `json:"ansible_become_flags,omitempty"`
-	AnsibleShellType         string `json:"ansible_shell_type,omitempty"`
-	AnsiblePythonInterpreter string `json:"ansible_python_interpreter,omitempty"`
-	AnsibleShellExecutable   string `json:"ansible_shell_executable,omitempty"`
+	AnsibleConnection        string            `json:"ansible_connection,omitempty"`
+	AnsibleHost              string            `json:"ansible_host,omitempty"`
+	AnsiblePort              int64             `json:"ansible_port,omitempty"`
+	AnsibleUser              string            `json:"ansible_user,omitempty"`
+	AnsiblePassword          string            `json:"ansible_password,omitempty"`
+	AnsiblePrivateKeyFile    string            `json:"ansible_private_key_file,omitempty"`
+	AnsibleSSHCommonArgs     string            `json:"ansible_ssh_common_args,omitempty"`
+	AnsibleSftpExtraArgs     string            `json:"ansible_sftp_extra_args,omitempty"`
+	AnsibleScpExtraArgs      string            `json:"ansible_scp_extra_args,omitempty"`
+	AnsibleSSHExtraArgs      string            `json:"ansible_ssh_extra_args,omitempty"`
+	AnsibleSSHPipelining     bool              `json:"ansible_ssh_pipelining,omitempty"`
+	AnsibleSSHExecutable     string            `json:"ansible_ssh_executable,omitempty"`
+	AnsibleBecome            bool              `json:"ansible_become,omitempty"`
+	AnsibleBecomeMethod      string            `json:"ansible_become_method,omitempty"`
+	AnsibleBecomeUser        string            `json:"ansible_become_user,omitempty"`
+	AnsibleBecomePassword    string            `json:"ansible_become_password,omitempty"`
+	AnsibleBecomeExe         string            `json:"ansible_become_exe,omitempty"`
+	AnsibleBecomeFlags       string            `json:"ansible_become_flags,omitempty"`
+	AnsibleShellType         string            `json:"ansible_shell_type,omitempty"`
+	AnsiblePythonInterpreter string            `json:"ansible_python_interpreter,omitempty"`
+	AnsibleShellExecutable   string            `json:"ansible_shell_executable,omitempty"`
+	Vars                     map[string]string `json:"-"`
+}
+
+func (h JsonHostModel) MarshalJSON() ([]byte, error) {
+	type HostAlias JsonHostModel
+
+	baseBytes, err := json.Marshal(HostAlias(h))
+	if err != nil {
+		return nil, err
+	}
+
+	var retMap map[string]any
+	if err := json.Unmarshal(baseBytes, &retMap); err != nil {
+		return nil, err
+	}
+
+	if retMap == nil {
+		retMap = make(map[string]any)
+	}
+
+	for k, v := range h.Vars {
+		if _, exists := retMap[k]; !exists {
+			retMap[k] = v
+		}
+	}
+
+	return json.Marshal(retMap)
 }
 
 // Schema implements datasource.Resource.
@@ -396,6 +435,12 @@ func (i *InventoryDataSource) Schema(
 							MarkdownDescription: "Allows you to set the shell executable to use for the target system.",
 							Required:            false,
 							Optional:            true,
+						},
+						"vars": schema.MapAttribute{
+							MarkdownDescription: "Custom variables to be set for the host.",
+							Required:            false,
+							Optional:            true,
+							ElementType:         types.StringType,
 						},
 					},
 				},

--- a/framework/data_inventory.go
+++ b/framework/data_inventory.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -284,12 +285,12 @@ func (h JsonHostModel) MarshalJSON() ([]byte, error) {
 
 	baseBytes, err := json.Marshal(HostAlias(h))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal base host configuration: %w", err)
 	}
 
 	var retMap map[string]any
 	if err := json.Unmarshal(baseBytes, &retMap); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal host bytes to map representation: %w", err)
 	}
 
 	if retMap == nil {
@@ -302,7 +303,12 @@ func (h JsonHostModel) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	return json.Marshal(retMap)
+	finalBytes, err := json.Marshal(retMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal final host map structure: %w", err)
+	}
+
+	return finalBytes, nil
 }
 
 // Schema implements datasource.Resource.

--- a/framework/data_inventory.go
+++ b/framework/data_inventory.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -192,7 +191,7 @@ func hostToJson(ctx context.Context, hostModel *HostModel) (json.RawMessage, dia
 		}
 	}
 
-	ret, err := json.Marshal(
+	baseBytes, err := json.Marshal(
 		JsonHostModel{
 			AnsibleConnection:        hostModel.AnsibleConnection.ValueString(),
 			AnsibleHost:              hostModel.AnsibleHost.ValueString(),
@@ -215,8 +214,29 @@ func hostToJson(ctx context.Context, hostModel *HostModel) (json.RawMessage, dia
 			AnsibleShellType:         hostModel.AnsibleShellType.ValueString(),
 			AnsiblePythonInterpreter: hostModel.AnsiblePythonInterpreter.ValueString(),
 			AnsibleShellExecutable:   hostModel.AnsibleShellExecutable.ValueString(),
-			Vars:                     hostVars,
 		})
+	if err != nil {
+		diags.Append(diag.NewErrorDiagnostic("Could not marshal host when marshalling inventory to JSON", err.Error()))
+		return nil, diags
+	}
+
+	var hostMap map[string]any
+	if err := json.Unmarshal(baseBytes, &hostMap); err != nil {
+		diags.Append(diag.NewErrorDiagnostic("Could not unmarshal host base JSON", err.Error()))
+		return nil, diags
+	}
+
+	if hostMap == nil {
+		hostMap = make(map[string]any)
+	}
+
+	for k, v := range hostVars {
+		if _, exists := hostMap[k]; !exists {
+			hostMap[k] = v
+		}
+	}
+
+	ret, err := json.Marshal(hostMap)
 	if err != nil {
 		diags.Append(diag.NewErrorDiagnostic("Could not marshal host when marshalling inventory to JSON", err.Error()))
 		return nil, diags
@@ -256,59 +276,27 @@ type HostModel struct {
 //
 //nolint:tagliatelle // Ansible requires snake_case JSON field names
 type JsonHostModel struct {
-	AnsibleConnection        string            `json:"ansible_connection,omitempty"`
-	AnsibleHost              string            `json:"ansible_host,omitempty"`
-	AnsiblePort              int64             `json:"ansible_port,omitempty"`
-	AnsibleUser              string            `json:"ansible_user,omitempty"`
-	AnsiblePassword          string            `json:"ansible_password,omitempty"`
-	AnsiblePrivateKeyFile    string            `json:"ansible_private_key_file,omitempty"`
-	AnsibleSSHCommonArgs     string            `json:"ansible_ssh_common_args,omitempty"`
-	AnsibleSftpExtraArgs     string            `json:"ansible_sftp_extra_args,omitempty"`
-	AnsibleScpExtraArgs      string            `json:"ansible_scp_extra_args,omitempty"`
-	AnsibleSSHExtraArgs      string            `json:"ansible_ssh_extra_args,omitempty"`
-	AnsibleSSHPipelining     bool              `json:"ansible_ssh_pipelining,omitempty"`
-	AnsibleSSHExecutable     string            `json:"ansible_ssh_executable,omitempty"`
-	AnsibleBecome            bool              `json:"ansible_become,omitempty"`
-	AnsibleBecomeMethod      string            `json:"ansible_become_method,omitempty"`
-	AnsibleBecomeUser        string            `json:"ansible_become_user,omitempty"`
-	AnsibleBecomePassword    string            `json:"ansible_become_password,omitempty"`
-	AnsibleBecomeExe         string            `json:"ansible_become_exe,omitempty"`
-	AnsibleBecomeFlags       string            `json:"ansible_become_flags,omitempty"`
-	AnsibleShellType         string            `json:"ansible_shell_type,omitempty"`
-	AnsiblePythonInterpreter string            `json:"ansible_python_interpreter,omitempty"`
-	AnsibleShellExecutable   string            `json:"ansible_shell_executable,omitempty"`
-	Vars                     map[string]string `json:"-"`
-}
-
-func (h JsonHostModel) MarshalJSON() ([]byte, error) {
-	type HostAlias JsonHostModel
-
-	baseBytes, err := json.Marshal(HostAlias(h))
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal base host configuration: %w", err)
-	}
-
-	var retMap map[string]any
-	if err := json.Unmarshal(baseBytes, &retMap); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal host bytes to map representation: %w", err)
-	}
-
-	if retMap == nil {
-		retMap = make(map[string]any)
-	}
-
-	for k, v := range h.Vars {
-		if _, exists := retMap[k]; !exists {
-			retMap[k] = v
-		}
-	}
-
-	finalBytes, err := json.Marshal(retMap)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal final host map structure: %w", err)
-	}
-
-	return finalBytes, nil
+	AnsibleConnection        string `json:"ansible_connection,omitempty"`
+	AnsibleHost              string `json:"ansible_host,omitempty"`
+	AnsiblePort              int64  `json:"ansible_port,omitempty"`
+	AnsibleUser              string `json:"ansible_user,omitempty"`
+	AnsiblePassword          string `json:"ansible_password,omitempty"`
+	AnsiblePrivateKeyFile    string `json:"ansible_private_key_file,omitempty"`
+	AnsibleSSHCommonArgs     string `json:"ansible_ssh_common_args,omitempty"`
+	AnsibleSftpExtraArgs     string `json:"ansible_sftp_extra_args,omitempty"`
+	AnsibleScpExtraArgs      string `json:"ansible_scp_extra_args,omitempty"`
+	AnsibleSSHExtraArgs      string `json:"ansible_ssh_extra_args,omitempty"`
+	AnsibleSSHPipelining     bool   `json:"ansible_ssh_pipelining,omitempty"`
+	AnsibleSSHExecutable     string `json:"ansible_ssh_executable,omitempty"`
+	AnsibleBecome            bool   `json:"ansible_become,omitempty"`
+	AnsibleBecomeMethod      string `json:"ansible_become_method,omitempty"`
+	AnsibleBecomeUser        string `json:"ansible_become_user,omitempty"`
+	AnsibleBecomePassword    string `json:"ansible_become_password,omitempty"`
+	AnsibleBecomeExe         string `json:"ansible_become_exe,omitempty"`
+	AnsibleBecomeFlags       string `json:"ansible_become_flags,omitempty"`
+	AnsibleShellType         string `json:"ansible_shell_type,omitempty"`
+	AnsiblePythonInterpreter string `json:"ansible_python_interpreter,omitempty"`
+	AnsibleShellExecutable   string `json:"ansible_shell_executable,omitempty"`
 }
 
 // Schema implements datasource.Resource.

--- a/framework/data_inventory.go
+++ b/framework/data_inventory.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"maps"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -62,7 +63,7 @@ func inventoryToJson(ctx context.Context, irm *InventoryDataSourceModel) ([]byte
 		diags.Append(diag.NewErrorDiagnostic("Could not marshal inventory to JSON", err.Error()))
 		return nil, diags
 	}
-	return ret, nil
+	return ret, diags
 }
 
 func groupsToJson(ctx context.Context, list types.List, level int) (map[string]json.RawMessage, diag.Diagnostics) {
@@ -72,12 +73,13 @@ func groupsToJson(ctx context.Context, list types.List, level int) (map[string]j
 	if level < groupNestingLevel {
 		// There is a deeper nesting level
 		var nestedGroups []NestedGroupModel
-		diags := list.ElementsAs(ctx, &nestedGroups, false)
-		if diags.HasError() {
+		if errDiag := list.ElementsAs(ctx, &nestedGroups, false); errDiag.HasError() {
+			diags.Append(errDiag...)
 			return nil, diags
 		}
 		for _, group := range nestedGroups {
-			groupJson, diags := nestedGroupToJson(ctx, group, level)
+			groupJson, groupDiags := nestedGroupToJson(ctx, group, level)
+			diags.Append(groupDiags...)
 			if diags.HasError() {
 				return nil, diags
 			}
@@ -91,13 +93,14 @@ func groupsToJson(ctx context.Context, list types.List, level int) (map[string]j
 	} else {
 		// This is the final nesting level
 		var finalGroups []FinalGroupModel
-		diags := list.ElementsAs(ctx, &finalGroups, false)
-		if diags.HasError() {
+		if errDiag := list.ElementsAs(ctx, &finalGroups, false); errDiag.HasError() {
+			diags.Append(errDiag...)
 			return nil, diags
 		}
 
 		for _, group := range finalGroups {
-			groupJson, diags := sharedGroupToJson(ctx, group.SharedGroupModel)
+			groupJson, groupDiags := sharedGroupToJson(ctx, group.SharedGroupModel)
+			diags.Append(groupDiags...)
 			if diags.HasError() {
 				return nil, diags
 			}
@@ -123,7 +126,8 @@ func nestedGroupToJson(
 		return nil, diags
 	}
 
-	groupsJson, diags := groupsToJson(ctx, group.Groups, level+1)
+	groupsJson, groupsDiags := groupsToJson(ctx, group.Groups, level+1)
+	diags.Append(groupsDiags...)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -148,7 +152,8 @@ func sharedGroupToJson(ctx context.Context, group SharedGroupModel) (map[string]
 
 	hostsJson := map[string]json.RawMessage{}
 	for _, host := range hosts {
-		hostJson, diags := hostToJson(ctx, &host)
+		hostJson, hostDiags := hostToJson(ctx, &host)
+		diags.Append(hostDiags...)
 		if diags.HasError() {
 			return nil, diags
 		}
@@ -164,8 +169,8 @@ func sharedGroupToJson(ctx context.Context, group SharedGroupModel) (map[string]
 	}
 
 	var vars map[string]string
-	diags = group.Vars.ElementsAs(ctx, &vars, false)
-	if diags.HasError() {
+	if errDiag := group.Vars.ElementsAs(ctx, &vars, false); errDiag.HasError() {
+		diags.Append(errDiag...)
 		return nil, diags
 	}
 	if len(vars) > 0 {
@@ -230,9 +235,14 @@ func hostToJson(ctx context.Context, hostModel *HostModel) (json.RawMessage, dia
 		hostMap = make(map[string]any)
 	}
 
-	for k, v := range hostVars {
-		if _, exists := hostMap[k]; !exists {
-			hostMap[k] = v
+	for key, value := range hostVars {
+		if _, exists := hostMap[key]; !exists {
+			hostMap[key] = value
+		} else {
+			diags.Append(diag.NewWarningDiagnostic(
+				"Ansible Host Variable Conflict",
+				fmt.Sprintf("The custom variable %q in vars was ignored because it conflicts with the built-in host attribute %q which has already been set.", key, key),
+			))
 		}
 	}
 

--- a/framework/data_inventory_internal_test.go
+++ b/framework/data_inventory_internal_test.go
@@ -1,0 +1,55 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostToJson_WarningOnConflict(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	varsMap, mapDiags := types.MapValueFrom(ctx, types.StringType, map[string]string{
+		"ansible_connection": "local", // Conflicts with explicit connection below
+		"custom_var":         "custom_value",
+	})
+	require.False(t, mapDiags.HasError())
+
+	hostModel := &HostModel{
+		AnsibleConnection: types.StringValue("ssh"),
+		Vars:              varsMap,
+	}
+
+	_, diags := hostToJson(ctx, hostModel)
+
+	assert.False(t, diags.HasError(), "Should not produce errors")
+
+	warnings := diags.Warnings()
+	require.Len(t, warnings, 1, "Should produce exactly 1 warning diagnostic")
+	assert.Contains(t, warnings[0].Summary(), "Ansible Host Variable Conflict")
+	assert.Contains(t, warnings[0].Detail(), "ansible_connection")
+}
+
+func TestHostToJson_NoWarningOnNoConflict(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	varsMap, mapDiags := types.MapValueFrom(ctx, types.StringType, map[string]string{
+		"custom_var": "custom_value",
+	})
+	require.False(t, mapDiags.HasError())
+
+	hostModel := &HostModel{
+		AnsibleConnection: types.StringValue("ssh"),
+		Vars:              varsMap,
+	}
+
+	_, diags := hostToJson(ctx, hostModel)
+
+	assert.False(t, diags.HasError())
+	assert.Empty(t, diags.Warnings(), "Should not produce any warning diagnostics")
+}

--- a/framework/data_inventory_test.go
+++ b/framework/data_inventory_test.go
@@ -1,0 +1,102 @@
+package framework_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+var (
+	errDataSourceNotFound = errors.New("data.ansible_inventory.test not found in state")
+	errInvalidInventory   = errors.New("invalid inventory JSON structure")
+	errValueMismatch      = errors.New("attribute value mismatch")
+)
+
+func TestAccInventoryDataSource_basic(t *testing.T) {
+	t.Parallel()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: ansibleProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+    data "ansible_inventory" "test" {
+      group {
+        name = "web"
+        host {
+          name         = "server01"
+          ansible_host = "1.2.3.4"
+          vars = {
+            custom_var = "custom_value"
+            port       = "8080"
+          }
+        }
+        host {
+          name		   = "server02"
+          ansible_host = "5.6.7.8"
+        }
+      }
+    }
+    `,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ansible_inventory.test", "json"),
+					func(s *terraform.State) error {
+						rs, exists := s.RootModule().Resources["data.ansible_inventory.test"]
+						if !exists {
+							return errDataSourceNotFound
+						}
+
+						jsonVal := rs.Primary.Attributes["json"]
+						var inventory map[string]any
+						if err := json.Unmarshal([]byte(jsonVal), &inventory); err != nil {
+							return fmt.Errorf("%w: failed to unmarshal: %w", errInvalidInventory, err)
+						}
+
+						webGroup, foundGroup := inventory["web"].(map[string]any)
+						if !foundGroup {
+							return fmt.Errorf("%w: web group missing or not a map", errInvalidInventory)
+						}
+
+						hosts, foundHosts := webGroup["hosts"].(map[string]any)
+						if !foundHosts {
+							return fmt.Errorf("%w: hosts map missing under web group", errInvalidInventory)
+						}
+
+						server1, foundServer1 := hosts["server01"].(map[string]any)
+						if !foundServer1 {
+							return fmt.Errorf("%w: server01 missing under hosts", errInvalidInventory)
+						}
+
+						if server1["ansible_host"] != "1.2.3.4" {
+							return fmt.Errorf("%w: expected ansible_host to be 1.2.3.4, got %v", errValueMismatch, server1["ansible_host"])
+						}
+						if server1["custom_var"] != "custom_value" {
+							return fmt.Errorf("%w: expected custom_var to be custom_value, got %v", errValueMismatch, server1["custom_var"])
+						}
+						if server1["port"] != "8080" {
+							return fmt.Errorf("%w: expected port to be 8080, got %v", errValueMismatch, server1["port"])
+						}
+
+						server2, foundServer2 := hosts["server02"].(map[string]any)
+						if !foundServer2 {
+							return fmt.Errorf("%w: server02 missing under hosts", errInvalidInventory)
+						}
+
+						if server2["ansible_host"] != "5.6.7.8" {
+							return fmt.Errorf("%w: expected ansible_host to be 5.6.7.8, got %v", errValueMismatch, server2["ansible_host"])
+						}
+						if _, hasCustomVar := server2["custom_var"]; hasCustomVar {
+							return fmt.Errorf("%w: server02 should not have custom_var", errValueMismatch)
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}

--- a/framework/data_inventory_test.go
+++ b/framework/data_inventory_test.go
@@ -16,7 +16,7 @@ var (
 	errValueMismatch      = errors.New("attribute value mismatch")
 )
 
-func TestAccInventoryDataSource_basic(t *testing.T) {
+func TestInventoryDataSource_basic(t *testing.T) {
 	t.Parallel()
 
 	resource.UnitTest(t, resource.TestCase{


### PR DESCRIPTION
Related issue: #160 

Adds `vars` attribute to `host` block inside `ansible_inventory` data source

Had to make a custom Marshaler to spread `JsonHostModel.Vars` into the resulting JSON

### Example:

```hcl
data "ansible_inventory" "myinventory" {
  group {
    name = "webservers"

    host {
      name                   = "test"
      ansible_user           = "ubuntu"
      ansible_ssh_extra_args = "-o StrictHostKeyChecking=no"
      vars = {
        port  = "3000"
        color = "red"
      }
    }
  }
}

resource "local_file" "myinventory" {
  content  = data.ansible_inventory.myinventory.json
  filename = "${path.module}/inventory.json"
}

```

Results in:

```json
{
  "webservers": {
    "children": {},
    "hosts": {
      "test": {
        "ansible_ssh_extra_args": "-o StrictHostKeyChecking=no",
        "ansible_user": "ubuntu",
        "color": "red",
        "port": "3000"
      }
    }
  }
}

```


First contribution so all feedback is appreciated!