### PR TITLE
fix:  not printing crucial stdout of failed task #161

### DIFF
--- a/changelogs/fragments/161-playbook-run-stdout-on-failure.yml
+++ b/changelogs/fragments/161-playbook-run-stdout-on-failure.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "action ansible_playbook_run - include playbook stdout in failure errors so fatal task messages are visible."

--- a/framework/action_playbook_run.go
+++ b/framework/action_playbook_run.go
@@ -711,9 +711,11 @@ func (a *runPlaybookRunAction) Invoke(ctx context.Context, req action.InvokeRequ
 	cmd := exec.CommandContext(ctx, ansiblePlaybookBinary, args...)
 
 	var stderr strings.Builder
-	cmd.Stderr = &stderr
-	cmd.Stdout = &TerraformUiWriter{
+	var stdout strings.Builder
+
+	stdoutWriter := &TerraformUiWriter{
 		send: func(s string) {
+			stdout.WriteString(s)
 			if !config.Quiet.ValueBool() {
 				resp.SendProgress(action.InvokeProgressEvent{
 					Message: "ansible-playbook: " + s,
@@ -721,6 +723,9 @@ func (a *runPlaybookRunAction) Invoke(ctx context.Context, req action.InvokeRequ
 			}
 		},
 	}
+
+	cmd.Stderr = &stderr
+	cmd.Stdout = stdoutWriter
 
 	if !config.Quiet.ValueBool() {
 		resp.SendProgress(action.InvokeProgressEvent{
@@ -730,19 +735,30 @@ func (a *runPlaybookRunAction) Invoke(ctx context.Context, req action.InvokeRequ
 
 	err := cmd.Run()
 
-	stderrStr := stderr.String()
+	// Flush any buffered stdout (including the final "fatal:" line).
+	_ = stdoutWriter.Close()
+
 	if err != nil {
-		if len(stderrStr) > 0 {
-			resp.Diagnostics.AddError(
-				"ansible-playbook failed",
-				stderrStr,
-			)
-			return
+		var detail strings.Builder
+
+		if stdout.Len() > 0 {
+			detail.WriteString(strings.TrimSpace(stdout.String()))
+		}
+
+		if stderr.Len() > 0 {
+			if detail.Len() > 0 {
+				detail.WriteString("\n")
+			}
+			detail.WriteString(strings.TrimSpace(stderr.String()))
+		}
+
+		if detail.Len() == 0 {
+			detail.WriteString(err.Error())
 		}
 
 		resp.Diagnostics.AddError(
-			"Failed to execute ansible-playbook",
-			err.Error(),
+			"ansible-playbook failed",
+			detail.String(),
 		)
 		return
 	}


### PR DESCRIPTION

When `ansible_playbook_run` fails, the provider only reports stderr.
Ansible emits most task failures (including `fatal:` messages) to stdout,
making it difficult to diagnose playbook failures.

Changes

- Flush the TerraformUiWriter after playbook execution to ensure buffered
  stdout is written.
- Include stdout along with stderr in failure diagnostics.